### PR TITLE
Change default of lastpkttime back to 0 for all libslink clients

### DIFF
--- a/apps/3rd-party/slarchive/src/slarchive.c
+++ b/apps/3rd-party/slarchive/src/slarchive.c
@@ -102,6 +102,10 @@ int main (int argc, char **argv) {
 
 	/* Allocate and initialize a new connection description */
 	slconn = sl_newslcd();
+	if ( slconn ) {
+		// Change default from libslink >= 2.6
+		slconn->lastpkttime = 0;
+	}
 
 	/* Process given parameters (command line and parameter file) */
 	if ( parameter_proc (argc, argv) < 0 ) {

--- a/apps/3rd-party/slinktool/src/slinktool.c
+++ b/apps/3rd-party/slinktool/src/slinktool.c
@@ -106,6 +106,9 @@ main (int argc, char **argv)
 
   /* Allocate and initialize a new connection description */
   slconn = sl_newslcd();
+  if ( slconn ) {
+    slconn->lastpkttime = 0;
+  }
   
   /* Process given parameters (command line and parameter file) */
   if ( parameter_proc (argc, argv) < 0 )

--- a/apps/utils/load_timetable.cc
+++ b/apps/utils/load_timetable.cc
@@ -282,6 +282,7 @@ int main(int argc, char **argv)
     slcd->netdly = 1;
     slcd->keepalive = 0;
     slcd->sladdr = address;
+    slcd->lastpkttime = 0;
   
     /* If no host is given for the SeedLink server, add 'localhost' */
     if(*slcd->sladdr == ':')

--- a/plugins/chain_plugin/chain_plugin.cc
+++ b/plugins/chain_plugin/chain_plugin.cc
@@ -1028,6 +1028,7 @@ StationGroup::StationGroup(const string &address, bool multi_init, bool batch_in
     slcd->keepalive = keepalive;
     slcd->netto = netto;
     slcd->netdly = netdly;
+    slcd->lastpkttime = 0;
   }
 
 StationGroup::~StationGroup()


### PR DESCRIPTION
It changes the default parameter lastpkttime of an slconn back to 0 in
* [x] slarchive
* [x] slinktool
* [x] chain plugin
* [x] loadtimetable