### PR TITLE
[libslink] precision and naming

### DIFF
--- a/libs/3rd-party/libslink/msrecord.c
+++ b/libs/3rd-party/libslink/msrecord.c
@@ -461,7 +461,7 @@ sl_msr_print (SLlog *log, SLMSrecord *msr, int details)
   else
   {
     sl_msr_dsamprate (msr, &dsamprate);
-    sl_log_rl (log, 0, 0, "%s, %d samples, %.10g Hz, %s (latency ~%1.1f sec)\n",
+    sl_log_rl (log, 0, 0, "%s, %d samples, %.10g Hz, %s (delay ~%1.3f sec)\n",
                sourcename, msr->fsdh.num_samples, dsamprate, stime, latency);
   }
 


### PR DESCRIPTION
This would be a modification of the info printed by slinktool:
1. What slinktool calls latency is called delay in scqc, that's why I propose to change the term latency to delay here.
2. As a SeisComP server should have relatively good timing precision (ntp is ~millisecond?) I think it would be ok and actually useful to print the previous with 3 digits precision.

Note that (2) is already requested on the original slinktool repo since a long time, but it never made it through. (1) is for self consistency within SeisComP context (it is often confusing at least in my groups). I hope it is Ok to break out from original slinktool implementation, but I don't know if there are rules on 3rd party source code modification...