### PR TITLE
fixed imp compatibility issues for python 3.12 and higher

### DIFF
--- a/apps/seedlink/config/seedlink.py
+++ b/apps/seedlink/config/seedlink.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import os, string, time, re, glob, shutil, sys, imp, resource
+import os, string, time, re, glob, shutil, sys, importlib.util, resource
 import seiscomp.kernel, seiscomp.config
 
 try:
@@ -194,7 +194,6 @@ class TemplateModule(seiscomp.kernel.Module):
     def _set(self, name, value, station_scope=True):
         if station_scope:
             self.station_params[name] = value
-
         else:
             self.global_params[name] = value
 
@@ -253,9 +252,12 @@ class Module(TemplateModule):
             if modname in sys.modules:
                 mod = sys.modules[modname]
             else:
-                # create a module
-                mod = imp.new_module(modname)
-                mod.__file__ = path
+                # Create a module spec
+                spec = importlib.util.spec_from_file_location(modname, path)
+                # Create a module from the spec
+                mod = importlib.util.module_from_spec(spec)
+                # Load the module
+                spec.loader.exec_module(mod)
 
                 # store it in sys.modules
                 sys.modules[modname] = mod

--- a/apps/seedlink/config/seedlink.py
+++ b/apps/seedlink/config/seedlink.py
@@ -252,12 +252,7 @@ class Module(TemplateModule):
             if modname in sys.modules:
                 mod = sys.modules[modname]
             else:
-                # Create a module spec
-                spec = importlib.util.spec_from_file_location(modname, path)
-                # Create a module from the spec
-                mod = importlib.util.module_from_spec(spec)
-                # Load the module
-                spec.loader.exec_module(mod)
+                mod = importlib.import_module(modname)
 
                 # store it in sys.modules
                 sys.modules[modname] = mod


### PR DESCRIPTION
Good day everyone.
I am making another PR to fix an issue where the 'imp' module was removed from python 3.12.
This fix uses the 'importlib' module to handle the creation of dynamic modules within the seedlink namespace.
This should work for all python 3.x versions, although it has only been tested on python3.12.
thanks.
