### PR TITLE
[chain] Allow station splitting and merging

### DIFF
--- a/templates/chain/setup.py
+++ b/templates/chain/setup.py
@@ -187,10 +187,13 @@ class SeedlinkPluginHandler:
 
     # Find out what chain.xml instance to use
     try:
+        net = seedlink.param("sources.chain.network")
+    except: net = seedlink.net
+    try:
         sta = seedlink.param("sources.chain.station")
     except: sta = seedlink.sta
 
-    station_key = seedlink.net + "." + sta
+    station_key = net + "." + sta
 
     chain_instance = 0
     if station_key in self.stations:


### PR DESCRIPTION
Allow the following use cases:

1. Merging 2 stations (VSU, WLF) into one (WLF) [duplicate id and ${out_network}.${out_station}]

```xml
  <group address="geofon.gfz-potsdam.de:18000"
         seqfile="/home/andres/seiscomp/var/run/seedlink/geofon.gfz-potsdam.de:18000.seq"
         lockfile="/home/andres/seiscomp/var/run/seedlink/geofon.gfz-potsdam.de:18000.pid"
         batchmode="yes">
    <station id="GE.WLF" name="VSU" network="GE" selectors="BH?" out_name="WLF"/>
    <station id="GE.WLF" name="WLF" network="GE" selectors="HH?" out_name="WLF"/>
  </group>
```

2. Splitting one station (WLF) into two (WLF, VSU). [duplicate ${in_network}.${in_station}]

```xml
  <group address="geofon.gfz-potsdam.de:18000"
         seqfile="/home/andres/seiscomp/var/run/seedlink/geofon.gfz-potsdam.de_1:18000.seq"
         lockfile="/home/andres/seiscomp/var/run/seedlink/geofon.gfz-potsdam.de_1:18000.pid"
         batchmode="yes">
    <station id="GE.VSU" name="WLF" network="GE" selectors="HH?" out_name="VSU"/>
  </group>
  <group address="geofon.gfz-potsdam.de:18000"
         seqfile="/home/andres/seiscomp/var/run/seedlink/geofon.gfz-potsdam.de_2:18000.seq"
         lockfile="/home/andres/seiscomp/var/run/seedlink/geofon.gfz-potsdam.de_2:18000.pid"
         batchmode="yes">
    <station id="GE.WLF" name="WLF" network="GE" selectors="HH?" out_name="WLF"/>
  </group>
```